### PR TITLE
Added time() and useServerTime

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,19 +17,10 @@ npm install node-binance-api --save
 ```javascript
 const binance = require('node-binance-api');
 binance.options({
-	'APIKEY':'<key>',
-	'APISECRET':'<secret>'
-});
-```
-
-To start playing in test/sandbox mode where orders are **NOT** _"real"_ orders use:
-
-```javascript
-const binance = require('node-binance-api');
-binance.options({
-	'APIKEY':'<key>',
-	'APISECRET':'<secret>',
-	'test':true
+	APIKEY: '<key>',
+	APISECRET: '<secret>',
+	useServerTime: true, // If you get timestamp errors, synchronize to server time at startup
+	test: true // If you want to use sandbox mode where orders are simulated
 });
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-binance-api",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Binance API for node https://github.com/jaggedsoft/node-binance-api",
   "main": "node-binance-api.js",
   "dependencies": {


### PR DESCRIPTION
Added time() and useServerTime options
1. You can now use the `useServerTime` option to synchronize with the servers time at startup
2. You can now pass a callback function to options() which runs after the synchronization is complete

```js
binance.options({
	APIKEY: '<key>',
	APISECRET: '<secret>',
	useServerTime: true
}, main);

function main() {
	binance.balance((error, balances) => {
		if ( error ) {
			console.error(error);
			return;
		}
		console.log("balances()", balances);
		console.log("BNB balance: ", balances.BNB.available);
	});
}
```