### PR TITLE
Websocket improvements

### DIFF
--- a/node-binance-api.js
+++ b/node-binance-api.js
@@ -580,6 +580,9 @@ LIMIT_MAKER
         max: function(object) {
             return Math.max.apply(Math, Object.keys(object));
         },
+        setOption: function(key, value) {
+            options[key] = value;
+		},
         options: function(opt, callback = false) {
             options = opt;
             if ( typeof options.recvWindow === 'undefined' ) options.recvWindow = default_options.recvWindow;
@@ -828,7 +831,9 @@ LIMIT_MAKER
             subscriptions: function() {
                 return subscriptions;
             },
-            terminate: function(endpoint) {
+            terminate: function(endpoint, disable_reconnect = true) {
+				if ( disable_reconnect ) options.reconnect = false; // Disable auto reconnect
+				// This will still allow pre-existing sockets to automatically reconnect
                 let ws = subscriptions[endpoint];
                 if ( !ws ) return;
                 options.log('WebSocket terminated:', endpoint);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-binance-api",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "description": "Binance API for node https://github.com/jaggedsoft/node-binance-api",
   "main": "node-binance-api.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-binance-api",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "Binance API for node https://github.com/jaggedsoft/node-binance-api",
   "main": "node-binance-api.js",
   "dependencies": {


### PR DESCRIPTION
Stop heartbeat of manually terminated sockets (Thanks keith1024)
WebSocket terminate() function disables reconnect
Can use setOption like follows:
`api.setOption('reconnect', true);`