### PR TITLE
v0.4.25

### DIFF
--- a/node-binance-api.js
+++ b/node-binance-api.js
@@ -11,6 +11,7 @@ module.exports = function() {
     const WebSocket = require('ws');
     const request = require('request');
     const crypto = require('crypto');
+    const file = require('fs');
     const stringHash = require('string-hash');
     const base = 'https://api.binance.com/api/';
     const wapi = 'https://api.binance.com/wapi/';
@@ -577,7 +578,9 @@ LIMIT_MAKER
             options[key] = value;
         },
         options: function(opt, callback = false) {
-            options = opt;
+            if ( typeof opt === 'string' ) { // Pass json config filename
+                options = JSON.parse(file.readFileSync(opt));
+            } else options = opt;
             if ( typeof options.recvWindow === 'undefined' ) options.recvWindow = default_options.recvWindow;
             if ( typeof options.useServerTime === 'undefined' ) options.useServerTime = default_options.useServerTime;
             if ( typeof options.reconnect === 'undefined' ) options.reconnect = default_options.reconnect;

--- a/node-binance-api.js
+++ b/node-binance-api.js
@@ -123,7 +123,6 @@ module.exports = function() {
         if ( !options.APISECRET ) throw Error('signedRequest: Invalid API Secret');
         if ( !data ) data = {};
         data.timestamp = new Date().getTime() + info.timeOffset;
-        if ( typeof data.symbol !== 'undefined' ) data.symbol = data.symbol.replace('_','');
         if ( typeof data.recvWindow === 'undefined' ) data.recvWindow = options.recvWindow;
         let query = Object.keys(data).reduce(function(a,k){a.push(k+'='+encodeURIComponent(data[k]));return a},[]).join('&');
         let signature = crypto.createHmac('sha256', options.APISECRET).update(query).digest('hex'); // set the HMAC hash header

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-binance-api",
-  "version": "0.4.24",
+  "version": "0.4.25",
   "description": "Binance API for node https://github.com/jaggedsoft/node-binance-api",
   "main": "node-binance-api.js",
   "dependencies": {


### PR DESCRIPTION
Read API keys from config file
Example: `binance.options("config.json");`
config.json would look like this:
```js
{
	"APIKEY": "z5RQZ9n8JcS3HLDQmPpfLQIGGQN6TTs5pCP5CTnn4nYk2ImFcew49v4ZrmP3MGl5",
	"APISECRET": "ZqePF1DcLb6Oa0CfcLWH0Tva59y8qBBIqu789JEY27jq0RkOKXpNl9992By1PN9Z",
	"verbose": true
}
```