### PR TITLE
Add roundTicks function to fix PRICE_FILTER errors

### DIFF
--- a/node-binance-api.js
+++ b/node-binance-api.js
@@ -814,13 +814,26 @@ let api = function Binance() {
 
         /**
         * rounds number with given step
-        * @param {float} number - number to round
-        * @param {float} stepSize - step size
+        * @param {float} number - quantity to round
+        * @param {float} stepSize - stepSize as specified by exchangeInfo
         * @return {float} - number
         */
         roundStep: function (number, stepSize) {
             const precision = stepSize.toString().split('.')[1].length || 0;
             return (((number / stepSize) | 0) * stepSize).toFixed(precision);
+        },
+        
+        /**
+        * rounds price to required precision
+        * @param {float} number - price to round
+        * @param {float} tickSize - tickSize as specified by exchangeInfo
+        * @return {float} - number
+        */
+        roundTicks: function (number, tickSize) {
+            const formatter = new Intl.NumberFormat('en-US', { style: 'decimal', minimumFractionDigits: 0, maximumFractionDigits: 8 });
+            const precision = formatter.format(tickSize).split('.')[1].length || 0;
+            if ( typeof number === 'string' ) number = parseFloat(number);
+            return number.toFixed(precision);
         },
 
         /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-binance-api",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Binance API for node https://github.com/jaggedsoft/node-binance-api",
   "main": "node-binance-api.js",
   "dependencies": {


### PR DESCRIPTION
Usage: binance.roundTicks(price, tickSize)
```js
function roundTicks(number, tickSize) {
    const formatter = new Intl.NumberFormat('en-US', { style: 'decimal', minimumFractionDigits: 0, maximumFractionDigits: 8 });
    const precision = formatter.format(tickSize).split('.')[1].length || 0;
    if ( typeof number === 'string' ) number = parseFloat(number);
    return number.toFixed(precision);
}
```